### PR TITLE
Update Checkout Actions from v2 to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: sudo apt-get install -y libboost-all-dev cmake


### PR DESCRIPTION
According to https://github.com/actions/checkout, update the checkout actions to latest version.

Sample repos in GitHub used an old version, which always lead to a warning when running GitHub Actions.